### PR TITLE
mediaType can be null - not throwing null exception

### DIFF
--- a/src/MultipartDataMediaFormatter/Converters/HttpContentToFormDataConverter.cs
+++ b/src/MultipartDataMediaFormatter/Converters/HttpContentToFormDataConverter.cs
@@ -42,7 +42,7 @@ namespace MultipartDataMediaFormatter.Converters
             {
                 var name = UnquoteToken(file.Headers.ContentDisposition.Name);
                 string fileName = FixFilename(file.Headers.ContentDisposition.FileName);
-                string mediaType = file.Headers.ContentType.MediaType;
+                string mediaType = file.Headers.ContentType?.MediaType;
 
                 using (var stream = await file.ReadAsStreamAsync())
                 {


### PR DESCRIPTION
If the client sending the file does not provide ContentType a null pointer exception was thrown previously.